### PR TITLE
Fix singularity blast

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ nextflow run goldrieve/vsgseq2 \
 
 ### 3. Conda
 
+We recommend running vsgseq2 with Docker or Singularity, however, you can also use Conda. This will build a conda env with dependencies, rather than pulling a pre-built image.
+
 ```bash
 nextflow run goldrieve/vsgseq2 \
   -r main \

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Run vsgseq2 on test data with one of Docker, Singularity or Conda:
 
 ```bash
 nextflow run goldrieve/vsgseq2 \
+  -r main \
   --samplesheet samples.csv \
   --outdir results \
   -profile docker
@@ -36,6 +37,7 @@ nextflow run goldrieve/vsgseq2 \
 
 ```bash
 nextflow run goldrieve/vsgseq2 \
+  -r main \
   --samplesheet samples.csv \
   --outdir results \
   -profile singularity
@@ -45,6 +47,7 @@ nextflow run goldrieve/vsgseq2 \
 
 ```bash
 nextflow run goldrieve/vsgseq2 \
+  -r main \
   --samplesheet samples.csv \
   --outdir results \
   -profile conda
@@ -148,21 +151,24 @@ Use the `--mode` flag to control which parts of the pipeline are executed.
 Run the full pipeline:
 
 ```bash
-nextflow run ../../main.nf \
+nextflow run goldrieve/vsgseq2 \
+  -r main \
   --mode full \
   --samplesheet samples.csv \
-  --outdir results/tutorial
+  --outdir results \
+  -profile docker
 ```
 
 Re-use Trinity assemblies and re-run the analysis section with a new threshold:
 
 ```bash
-nextflow run ../../main.nf \
+nextflow run goldrieve/vsgseq2 \
+  -r main \
   --mode analyse \
   --samplesheet samples.csv \
-  --assemblies 'results/tutorial/assemblies/*_trinity.Trinity.fasta' \
   --threshold 200000 \
   --outdir results/tutorial_200000
+  -profile docker
 ```
 
 ## Command-line Options

--- a/data/reads/samples.csv
+++ b/data/reads/samples.csv
@@ -1,3 +1,5 @@
 sample,r1,r2
 early_1,early_1_1.fastq.gz,early_1_2.fastq.gz
 late_1,late_1_1.fq.gz,late_1_2.fq.gz
+earlysingle,earlysingle.fq.gz,
+latesingle,latesingle.fq.gz,

--- a/data/reads/samples.csv
+++ b/data/reads/samples.csv
@@ -1,5 +1,3 @@
 sample,r1,r2
 early_1,early_1_1.fastq.gz,early_1_2.fastq.gz
 late_1,late_1_1.fq.gz,late_1_2.fq.gz
-earlysingle,earlysingle.fq.gz,
-latesingle,latesingle.fq.gz,

--- a/main.nf
+++ b/main.nf
@@ -171,6 +171,13 @@ workflow vsgseq2 {
         [ meta, reads ]
     }
 
+    // Create channels for BLAST database directories
+    vsg_db_dir = file(params.vsg_db).parent
+    notvsg_db_dir = file(params.notvsg_db).parent
+    
+    ch_vsg_db = Channel.fromPath("${vsg_db_dir}/*").collect()
+    ch_notvsg_db = Channel.fromPath("${notvsg_db_dir}/*").collect()
+
     if (params.mode == "full") {
         TRIM(
             ch_reads,
@@ -188,8 +195,8 @@ workflow vsgseq2 {
             )
         BLAST(
             ORF.out,
-            params.vsg_db,
-            params.notvsg_db
+            ch_vsg_db,
+            ch_notvsg_db
             )
         CONCATENATE_VSGS(
             (BLAST.out.vsgs).collect(),
@@ -238,8 +245,8 @@ workflow vsgseq2 {
             )
         BLAST(
             ORF.out,
-            params.vsg_db,
-            params.notvsg_db
+            ch_vsg_db,
+            ch_notvsg_db
             )
         CONCATENATE_VSGS(
             (BLAST.out.vsgs).collect(),

--- a/main.nf
+++ b/main.nf
@@ -171,8 +171,6 @@ workflow vsgseq2 {
         [ meta, reads ]
     }
 
-    // Create channels for BLAST database files (main file + all index files)
-    // Combine both databases into a single channel so they're all staged together
     ch_blast_dbs = Channel.fromPath("${params.vsg_db}*")
         .mix(Channel.fromPath("${params.notvsg_db}*"))
         .collect()

--- a/modules/blast.nf
+++ b/modules/blast.nf
@@ -14,12 +14,11 @@ process BLAST {
         def basename = assemblies.simpleName.replace('_cdhit', '')
         basename = (params.mode == 'full' || params.mode == 'analyse') ? basename : basename + '_cdhit'
         
-        // Extract the database basename from the params
-        def vsg_db_name = file(params.vsg_db).name.replaceAll(/\.(fa|fasta)$/, '')
-        def notvsg_db_name = file(params.notvsg_db).name.replaceAll(/\.(fa|fasta)$/, '')
+        def vsg_db = file(params.vsg_db).name.replaceAll(/\.(fa|fasta)$/, '')
+        def notvsg_db = file(params.notvsg_db).name.replaceAll(/\.(fa|fasta)$/, '')
         """
-        blastn -db db_files/${vsg_db_name}.fa -query ${assemblies} -outfmt 5 -out ${basename}.xml
-        blastn -db db_files/${notvsg_db_name}.fa -query ${assemblies} -outfmt 5 -out ${basename}_nonVSG.xml
+        blastn -db db_files/${vsg_db}.fa -query ${assemblies} -outfmt 5 -out ${basename}.xml
+        blastn -db db_files/${notvsg_db}.fa -query ${assemblies} -outfmt 5 -out ${basename}_nonVSG.xml
         python ${params.scripts}process_vsgs.py ${basename}
         """
 }

--- a/modules/blast.nf
+++ b/modules/blast.nf
@@ -3,8 +3,7 @@ process BLAST {
     
     input:
         path assemblies
-        path vsg_db_dir
-        path notvsg_db_dir
+        path "db_files/*"
 
     output:
         path "*.xml", emit: vsgblast
@@ -15,11 +14,12 @@ process BLAST {
         def basename = assemblies.simpleName.replace('_cdhit', '')
         basename = (params.mode == 'full' || params.mode == 'analyse') ? basename : basename + '_cdhit'
         
+        // Extract the database basename from the params
         def vsg_db_name = file(params.vsg_db).name.replaceAll(/\.(fa|fasta)$/, '')
         def notvsg_db_name = file(params.notvsg_db).name.replaceAll(/\.(fa|fasta)$/, '')
         """
-        blastn -db ${vsg_db_dir}/${vsg_db_name} -query ${assemblies} -outfmt 5 -out ${basename}.xml
-        blastn -db ${notvsg_db_dir}/${notvsg_db_name} -query ${assemblies} -outfmt 5 -out ${basename}_nonVSG.xml
+        blastn -db db_files/${vsg_db_name}.fa -query ${assemblies} -outfmt 5 -out ${basename}.xml
+        blastn -db db_files/${notvsg_db_name}.fa -query ${assemblies} -outfmt 5 -out ${basename}_nonVSG.xml
         python ${params.scripts}process_vsgs.py ${basename}
         """
 }

--- a/modules/blast.nf
+++ b/modules/blast.nf
@@ -3,8 +3,8 @@ process BLAST {
     
     input:
         path assemblies
-        val vsg_db
-        val notvsg_db
+        path vsg_db_dir
+        path notvsg_db_dir
 
     output:
         path "*.xml", emit: vsgblast
@@ -14,9 +14,12 @@ process BLAST {
     script:
         def basename = assemblies.simpleName.replace('_cdhit', '')
         basename = (params.mode == 'full' || params.mode == 'analyse') ? basename : basename + '_cdhit'
+        
+        def vsg_db_name = file(params.vsg_db).name.replaceAll(/\.(fa|fasta)$/, '')
+        def notvsg_db_name = file(params.notvsg_db).name.replaceAll(/\.(fa|fasta)$/, '')
         """
-        blastn -db ${vsg_db} -query ${assemblies} -outfmt 5 -out ${basename}.xml
-        blastn -db ${notvsg_db} -query ${assemblies} -outfmt 5 -out ${basename}_nonVSG.xml
+        blastn -db ${vsg_db_dir}/${vsg_db_name} -query ${assemblies} -outfmt 5 -out ${basename}.xml
+        blastn -db ${notvsg_db_dir}/${notvsg_db_name} -query ${assemblies} -outfmt 5 -out ${basename}_nonVSG.xml
         python ${params.scripts}process_vsgs.py ${basename}
         """
 }

--- a/modules/summarise.nf
+++ b/modules/summarise.nf
@@ -34,9 +34,11 @@ process SUMMARISE {
 
 
     script:
+        def quants_array = quants instanceof List ? "[${quants.join(', ')}]" : "[${quants}]"
+        def vsgs_array = vsgs instanceof List ? "[${vsgs.join(', ')}]" : "[${vsgs}]"
         """
-        Rscript ${params.scripts}summarise_quant.R "${quants}" ${threshold}
-        Rscript ${params.scripts}summarise_vsgs.R "${vsgs}"
+        Rscript ${params.scripts}summarise_quant.R "${quants_array}" ${threshold}
+        Rscript ${params.scripts}summarise_vsgs.R "${vsgs_array}"
         python ${params.scripts}add_cluster.py filtered_tpm.csv ${clstr} filtered_tpm_clusters.csv
         python ${params.scripts}length.py "${fasta}" length.csv
         python ${params.scripts}merge_length_tpm.py filtered_tpm.csv length.csv filtered_tpm_clusters_length.csv

--- a/modules/summarise.nf
+++ b/modules/summarise.nf
@@ -13,11 +13,11 @@ process SUMMARISE {
     publishDir "${params.outdir}/summary/cluster", mode:'copy', pattern: "champion_vsgs.fasta"
     
     input:
-        val quants
+        path quants
         val threshold
-        val vsgs
-        val clstr
-        val fasta
+        path vsgs
+        path clstr
+        path fasta
 
     output:
         path "tpm.csv", emit: tpm

--- a/nf-test.config
+++ b/nf-test.config
@@ -3,5 +3,4 @@ config {
     testsDir "tests"
     workDir ".nf-test"
     configFile "nextflow.config"
-    profile "docker"
 }

--- a/nf-test.config
+++ b/nf-test.config
@@ -3,4 +3,5 @@ config {
     testsDir "tests"
     workDir ".nf-test"
     configFile "nextflow.config"
+    profile "docker"
 }

--- a/tests/modules/blast.nf.test
+++ b/tests/modules/blast.nf.test
@@ -15,8 +15,9 @@ nextflow_process {
             process {
                 """
                 input [0] = "$projectDir/tests/data/latesingle_trinity_cdhit.fasta"
-                input [1] = params.vsg_db
-                input [2] = params.notvsg_db 
+                input [1] = Channel.fromPath("$projectDir/data/blastdb/concatAnTattb427.fa*")
+                    .mix(Channel.fromPath("$projectDir/data/blastdb/vsgseq2NOTvsgs.fa*"))
+                    .collect()
                 """
             }
         }

--- a/tests/modules/summarise.nf.test
+++ b/tests/modules/summarise.nf.test
@@ -13,9 +13,9 @@ nextflow_process {
             }
             process {
                 """
-                input[0] = "${projectDir}/tests/data/early_1_quant/, ${projectDir}/tests/data/late_1_quant/"
+                input[0] = Channel.fromPath(["${projectDir}/tests/data/early_1_quant", "${projectDir}/tests/data/late_1_quant"]).collect()
                 input[1] = params.threshold
-                input[2] = "${projectDir}/tests/data/latesingle_ORF_VSGs.fasta"
+                input[2] = Channel.fromPath("${projectDir}/tests/data/latesingle_ORF_VSGs.fasta").collect()
                 input[3] = "${projectDir}/tests/data/VSGome.fasta.clstr"
                 input[4] = "${projectDir}/tests/data/VSGome.fasta"
                 """

--- a/vsgseq2.yml
+++ b/vsgseq2.yml
@@ -3,13 +3,14 @@ name: vsgseq2-env
 channels:
   - conda-forge
   - bioconda
-  - nodefaults
+  - defaults
 dependencies:
-  - trinity
-  - r-base
+  - python=3.9
+  - biopython
   - numpy
-  - python=3.8
+  - pandas
   - bioconda::blast
+  - bioconda::trinity=2.15.1
   - bowtie2
   - cd-hit=4.8.1
   - salmon=1.10.3
@@ -18,11 +19,8 @@ dependencies:
   - seqtk=1.4
   - bioconda::transdecoder
   - trimmomatic=0.39
-  - bioconda::trinity=2.15.1
-  - biopython=1.78
+  - r-base
   - r-pacman
-  - conda-forge::boost=1.85.0
   - multiqc=1.21
   - typing_extensions
   - nextflow
-  - anaconda::pandas


### PR DESCRIPTION
This pull request updates vsgseq2 to improve how BLAST database files are handled and clarifies usage in the documentation. The main changes are: switching from passing BLAST database file paths as values to using channels and paths, updating the `BLAST` process to expect database files in a directory, and updating documentation and test data for clarity and consistency.

The pipeline was working with Docker and Conda, but failed with Singularity. This fixes the issue with Singularity and maintains functionality with Docker and Conda.